### PR TITLE
#24 locale to localStorage

### DIFF
--- a/src/components/LocaleToggle/LocaleToggle.tsx
+++ b/src/components/LocaleToggle/LocaleToggle.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import { useTranslation } from 'react-i18next';
@@ -8,24 +8,37 @@ const LocaleToggle: FC = () => {
     const [locale, setLocale] = useState(Locale.EN);
     const { i18n } = useTranslation();
 
-    const handleChange = (_: React.MouseEvent<HTMLElement>, nextLocale: Locale) => {
-        const changeLanguage = async () => {
-            await i18n.changeLanguage(nextLocale).then(() =>
-                setLocale(nextLocale)
-            )
+    const changeLanguage = async (nextLocale: Locale) => {
+        await i18n.changeLanguage(nextLocale).then(() => {
+            setLocale(nextLocale);
+            localStorage.setItem('locale', nextLocale);
+        });
+    }
+
+    useEffect(() => {
+        const savedLocale = localStorage.getItem('locale');
+        if (savedLocale) {
+            changeLanguage(savedLocale as Locale).catch((e: Error) => {
+                console.error(e)
+            })
         }
-        changeLanguage().catch((e: Error) => {
+    }, []);
+
+    const handleChange = (_: React.MouseEvent<HTMLElement>, nextLocale: Locale) => {
+        changeLanguage(nextLocale).catch((e: Error) => {
             console.error(e)
         })
     }
 
-    return <ToggleButtonGroup
-        exclusive
-        value={locale}
-        onChange={handleChange}>
-        <ToggleButton value={Locale.EN}>English</ToggleButton>
-        <ToggleButton value={Locale.JA}>日本語</ToggleButton>
-    </ToggleButtonGroup>
+    return (
+        <ToggleButtonGroup
+            exclusive
+            value={locale}
+            onChange={handleChange}>
+            <ToggleButton value={Locale.EN}>English</ToggleButton>
+            <ToggleButton value={Locale.JA}>日本語</ToggleButton>
+        </ToggleButtonGroup>
+    );
 }
 
 export default LocaleToggle

--- a/src/components/LocaleToggle/LocaleToggle.tsx
+++ b/src/components/LocaleToggle/LocaleToggle.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect, useState, useCallback } from 'react'
 import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import { useTranslation } from 'react-i18next';
@@ -8,12 +8,12 @@ const LocaleToggle: FC = () => {
     const [locale, setLocale] = useState(Locale.EN);
     const { i18n } = useTranslation();
 
-    const changeLanguage = async (nextLocale: Locale) => {
+    const changeLanguage = useCallback(async (nextLocale: Locale) => {
         await i18n.changeLanguage(nextLocale).then(() => {
             setLocale(nextLocale);
             localStorage.setItem('locale', nextLocale);
         });
-    }
+    }, [i18n]);
 
     useEffect(() => {
         const savedLocale = localStorage.getItem('locale');
@@ -22,7 +22,7 @@ const LocaleToggle: FC = () => {
                 console.error(e)
             })
         }
-    }, []);
+    }, [changeLanguage]);
 
     const handleChange = (_: React.MouseEvent<HTMLElement>, nextLocale: Locale) => {
         changeLanguage(nextLocale).catch((e: Error) => {

--- a/src/components/LocaleToggle/__test__/LocaleToggle.test.tsx
+++ b/src/components/LocaleToggle/__test__/LocaleToggle.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@/tests/customRender'
+import LocaleToggle from '../LocaleToggle';
+import userEvent from '@testing-library/user-event'
+
+describe('LocaleToggle', () => {
+    it('renders correctly', () => {
+        const { getByText } = render(<LocaleToggle />);
+        expect(getByText('English')).toBeInTheDocument();
+        expect(getByText('日本語')).toBeInTheDocument();
+    });
+})
+
+it('changes locale when toggling', async () => {
+    const { getByText } = render(<LocaleToggle />);
+    const japaneseButton = getByText('日本語');
+
+    const user = userEvent.setup()
+    await user.click(japaneseButton)
+    expect(localStorage.getItem('locale')).toBe('ja');
+
+    localStorage.removeItem('locale');
+});

--- a/src/components/LocaleToggle/__test__/LocaleToggle.test.tsx
+++ b/src/components/LocaleToggle/__test__/LocaleToggle.test.tsx
@@ -2,18 +2,22 @@ import { describe, expect, it } from 'vitest'
 import { render } from '@/tests/customRender'
 import LocaleToggle from '../LocaleToggle';
 import userEvent from '@testing-library/user-event'
+import { screen } from '@testing-library/react'
 
 describe('LocaleToggle', () => {
-    it('renders correctly', () => {
-        const { getByText } = render(<LocaleToggle />);
-        expect(getByText('English')).toBeInTheDocument();
-        expect(getByText('日本語')).toBeInTheDocument();
+    it('renders correctly', async () => {
+        render(<LocaleToggle />)
+
+        const english = await screen.findByText('English');
+        const japanese = await screen.findByText('日本語');
+        expect(english).toBeInTheDocument();
+        expect(japanese).toBeInTheDocument();
     });
 })
 
 it('changes locale when toggling', async () => {
-    const { getByText } = render(<LocaleToggle />);
-    const japaneseButton = getByText('日本語');
+    render(<LocaleToggle />);
+    const japaneseButton = screen.getByText('日本語');
 
     const user = userEvent.setup()
     await user.click(japaneseButton)


### PR DESCRIPTION
Resolves #24 

## What changed 🧐
Save selected language to local storage when the user interacts with toggle in drawer. With useEffect, at page load evaluate if the localStorage has a language value and render the content in the correct language

## How did you test it? 🧪

Added `LocaleToggle.test.tsx` test file that ensures toggle is rendered and that checks that the language is correctly switched