### PR TITLE
#33 side drawer icon

### DIFF
--- a/src/components/SideDrawer/SideDrawer.tsx
+++ b/src/components/SideDrawer/SideDrawer.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from 'react'
 import SwipeableDrawer from '@mui/material/SwipeableDrawer'
 import IconButton from '@mui/material/IconButton'
 import DrawerContents from './DrawerContents'
-import StarIcon from '@mui/icons-material/Star'
+import MenuIcon from '@mui/icons-material/Menu'
 
 
 const SideDrawer: FC = () => {
@@ -29,7 +29,7 @@ const SideDrawer: FC = () => {
             onClick={() => { setOpen(true) }}
             aria-label="drawer-toggle-button"
         >
-            <StarIcon />
+            <MenuIcon />
         </IconButton>
         <SwipeableDrawer
             open={open}


### PR DESCRIPTION
Resolves #33 

## What changed 🧐
Replaced star icon to open the sidebar drawer. 
I also noticed that there is no X icon to close the sidebar drawer. Do we want to add this / do it in this same PR?


## How did you test it? 🧪
Tested visually
<img width="300" alt="Hamburger menu icon" src="https://github.com/WomenInSoftwareEngineeringJP/home/assets/39148794/c2294d7b-f42e-42cd-9999-809538304e95">
