### PR TITLE
switch to hash router to avoid 404 bug

### DIFF
--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import {
-    createBrowserRouter,
+    createHashRouter,
     RouterProvider,
 } from 'react-router-dom'
 import ThemePreview from './ThemePreview/ThemePreview'
@@ -9,7 +9,7 @@ import BaseLayout from './BaseLayout'
 import NotFound from './NotFound/NotFound'
 import CodeOfConduct from './CodeOfConduct/CodeOfConduct'
 
-const browserRouter = createBrowserRouter([{
+const browserRouter = createHashRouter([{
     element: <BaseLayout />,
     children: [
         {


### PR DESCRIPTION
Resolves #29 

## What changed 🧐
Replace browser router with hash router to ensure direct navigation to routes is possible


## How did you test it? 🧪
Manual testing:
Visit http://localhost:5173/#/codeofconduct
Navigate to Code of conduct via buttons. 

(Unfortunately we'll have to test this one in production to fully understand if it works)
