### PR TITLE
56 close button fix tests

### DIFF
--- a/e2e/team.spec.ts
+++ b/e2e/team.spec.ts
@@ -45,7 +45,7 @@ test('shows the team in English', async ({ page }) => {
     await expect(annLink).toHaveAttribute('target', '_blank')
 })
 
-test('shows the team in Japanese', async ({ page }) => {
+test('shows the team in Japanese', async ({ page, viewport }) => {
     await page.goto('/#/team')
 
     // switch locale to Japanese
@@ -56,8 +56,13 @@ test('shows the team in Japanese', async ({ page }) => {
 
     const teamContainer = page.getByLabel('team-container')
 
-    // click off to close sidebar
-    await teamContainer.click({ force: true })
+    // close the sidebar
+    if (viewport && viewport.width < 600) {
+        const closeButton = page.getByLabel('close-button')
+        await closeButton.click()
+    } else {
+        await teamContainer.click({ force: true })
+    }
 
     const heading = teamContainer.getByText('✨ リーダーシップ・チーム ✨')
     await expect(heading).toBeVisible()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
-    retries: process.env.CI ? 2 : 0,
+    retries: process.env.CI ? 2 : 1,
     /* Opt out of parallel tests on CI. */
     workers: process.env.CI ? 1 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -29,6 +29,8 @@ export default defineConfig({
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
     },
+    outputDir: './playwright-report',
+
 
     /* Configure projects for major browsers */
     projects: [

--- a/src/components/SideDrawer/DrawerContents.tsx
+++ b/src/components/SideDrawer/DrawerContents.tsx
@@ -20,10 +20,6 @@ const DrawerContents: FC<DrawerContentsProps> = ({ closeDrawer }) => {
     const theme = useTheme()
     const { t } = useTranslation()
 
-    const closeButton = <IconButton onClick={closeDrawer} aria-label='close-button'>
-        <CloseIcon />
-    </IconButton>
-
     let navList = <></>
     if (useMediaQuery(theme.breakpoints.down('sm'))) {
         navList = (<>
@@ -31,7 +27,9 @@ const DrawerContents: FC<DrawerContentsProps> = ({ closeDrawer }) => {
                 <Stack direction='row' sx={{ width: '100%', m: 0, p: 0 }}>
                     <StyledNavLink to='/'>Home</StyledNavLink>
                     <Box sx={{ display: 'flex-grow', width: '100%' }} />
-                    {closeButton}
+                    <IconButton onClick={closeDrawer} aria-label='close-button'>
+                        <CloseIcon />
+                    </IconButton>
                 </Stack>
             </ListItem>
             <ListItem>

--- a/src/components/SideDrawer/DrawerContents.tsx
+++ b/src/components/SideDrawer/DrawerContents.tsx
@@ -3,20 +3,33 @@ import Box from '@mui/material/Box'
 import Divider from '@mui/material/Divider'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
+import IconButton from '@mui/material/IconButton'
+import CloseIcon from '@mui/icons-material/Close'
+import Stack from '@mui/material/Stack'
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import StyledNavLink from '../StyledNavLink/StyledNavLink'
 import LocaleToggle from '../LocaleToggle/LocaleToggle'
 import { useTranslation } from 'react-i18next'
 
-const DrawerContents: FC = () => {
+interface DrawerContentsProps {
+    closeDrawer: () => void
+}
+
+const DrawerContents: FC<DrawerContentsProps> = ({ closeDrawer }) => {
     const theme = useTheme()
     const { t } = useTranslation()
     let navList = <></>
     if (useMediaQuery(theme.breakpoints.down('sm'))) {
         navList = (<>
             <ListItem>
-                <StyledNavLink to='/'>Home</StyledNavLink>
+                <Stack direction='row' sx={{ width: '100%', m: 0, p: 0 }}>
+                    <StyledNavLink to='/'>Home</StyledNavLink>
+                    <Box sx={{ display: 'flex-grow', width: '100%' }} />
+                    <IconButton onClick={closeDrawer} aria-label='close-button'>
+                        <CloseIcon />
+                    </IconButton>
+                </Stack>
             </ListItem>
             <ListItem>
                 <StyledNavLink to='/team'>{t('sidebar.team')}</StyledNavLink>
@@ -28,7 +41,7 @@ const DrawerContents: FC = () => {
         </>)
     }
 
-    return <Box sx={{ width: 300 }}>
+    return <Box sx={{ width: 300 }} aria-label='drawer-contents'>
         <List>
             {navList}
             <ListItem>

--- a/src/components/SideDrawer/DrawerContents.tsx
+++ b/src/components/SideDrawer/DrawerContents.tsx
@@ -19,6 +19,11 @@ interface DrawerContentsProps {
 const DrawerContents: FC<DrawerContentsProps> = ({ closeDrawer }) => {
     const theme = useTheme()
     const { t } = useTranslation()
+
+    const closeButton = <IconButton onClick={closeDrawer} aria-label='close-button'>
+        <CloseIcon />
+    </IconButton>
+
     let navList = <></>
     if (useMediaQuery(theme.breakpoints.down('sm'))) {
         navList = (<>
@@ -26,9 +31,7 @@ const DrawerContents: FC<DrawerContentsProps> = ({ closeDrawer }) => {
                 <Stack direction='row' sx={{ width: '100%', m: 0, p: 0 }}>
                     <StyledNavLink to='/'>Home</StyledNavLink>
                     <Box sx={{ display: 'flex-grow', width: '100%' }} />
-                    <IconButton onClick={closeDrawer} aria-label='close-button'>
-                        <CloseIcon />
-                    </IconButton>
+                    {closeButton}
                 </Stack>
             </ListItem>
             <ListItem>

--- a/src/components/SideDrawer/SideDrawer.tsx
+++ b/src/components/SideDrawer/SideDrawer.tsx
@@ -37,7 +37,7 @@ const SideDrawer: FC = () => {
             onClose={toggleDrawer(false)}
             aria-label="drawer"
         >
-            <DrawerContents />
+            <DrawerContents closeDrawer={() => { setOpen(false) }} />
         </SwipeableDrawer>
     </>
 }

--- a/src/components/SideDrawer/__test__/TestDrawerContents.test.tsx
+++ b/src/components/SideDrawer/__test__/TestDrawerContents.test.tsx
@@ -1,13 +1,33 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { render } from '@/tests/customRender'
 import { screen } from '@testing-library/react'
 import DrawerContents from '../DrawerContents'
+import userEvent from '@testing-library/user-event'
+import useMediaQuery from '@mui/material/useMediaQuery'
+
+vi.mock('@mui/material/useMediaQuery', () => {
+    return {
+        default: vi.fn()
+    }
+})
 
 describe('DrawerContents', () => {
     it('should display the DrawerContents', async () => {
-        render(<DrawerContents />)
+        render(<DrawerContents closeDrawer={() => { }} />)
         const japanese = await screen.findByText('日本語')
         expect(japanese).toBeVisible()
+    })
+
+    it('should call closeDrawer when clicking x on mobile viewport', async () => {
+        const mock = vi.fn(() => { })
+        const user = userEvent.setup()
+        vi.mocked(useMediaQuery).mockReturnValue(true)
+
+        render(<DrawerContents closeDrawer={mock} />)
+        const closeButton = await screen.findByLabelText('close-button')
+        await user.click(closeButton)
+
+        expect(mock).toHaveBeenCalled()
     })
 
     it.todo('should show the NavLinks on mobile screens')

--- a/src/components/SideDrawer/__test__/TestSideDrawer.test.tsx
+++ b/src/components/SideDrawer/__test__/TestSideDrawer.test.tsx
@@ -1,10 +1,21 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@/tests/customRender'
 import { screen, waitFor } from '@testing-library/react'
 import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
 import SideDrawer from '../SideDrawer'
 import userEvent from '@testing-library/user-event'
+import useMediaQuery from '@mui/material/useMediaQuery'
+
+vi.mock('@mui/material/useMediaQuery', () => {
+    return {
+        default: vi.fn()
+    }
+})
+
+beforeEach(() => {
+    vi.resetAllMocks()
+})
 
 describe('SideDrawer', () => {
     it('should initially render the Drawer closed', async () => {
@@ -59,6 +70,26 @@ describe('SideDrawer', () => {
 
         await waitFor(() => {
             expect(drawer).not.toBeVisible()
+        })
+    })
+
+    it('should close the Drawer when clicking the close icon on mobile view', async () => {
+        const user = userEvent.setup()
+        vi.mocked(useMediaQuery).mockReturnValue(true)
+
+        render(<SideDrawer />)
+
+        const button = await screen.findByLabelText('drawer-toggle-button')
+        await user.click(button)
+
+        const drawerContents = await screen.findByLabelText('drawer-contents')
+        expect(drawerContents).toBeVisible()
+
+        const closeButton = await screen.findByLabelText('close-button')
+        await user.click(closeButton)
+
+        await waitFor(() => {
+            expect(drawerContents).not.toBeVisible()
         })
     })
 })


### PR DESCRIPTION
Resolves #56 

## What changed 🧐
- Add a close button on mobile viewports
- Instrument vitest to mock `useMediaQuery` and test on mobile viewports
- Fix the failing playwright tests by correctly closing the sidebar


## How did you test it? 🧪

New unit tests, e2e tests, manual testing
