### PR TITLE
Eslint stylistic improvements

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,7 +15,7 @@ module.exports = {
     },
     plugins: [
         'react-refresh',
-        '@stylistic/ts'
+        '@stylistic'
     ],
     rules: {
         'react-refresh/only-export-components': [
@@ -26,8 +26,12 @@ module.exports = {
         'quotes': ['error', 'single'],
         '@typescript-eslint/prefer-nullish-coalescing': 'off',
         '@typescript-eslint/no-unsafe-call': ['off'],
-        '@stylistic/ts/indent': ['error', 4],
-        '@stylistic/ts/semi': ['error', 'never'],
+        '@stylistic/indent': ['error', 4],
+        '@stylistic/semi': ['error', 'never'],
+        '@stylistic/no-multi-spaces': 'error',
+        '@stylistic/no-trailing-spaces': 'error',
+        '@stylistic/no-mixed-spaces-and-tabs': 'error',
+        '@typescript-eslint/no-explicit-any': 'error',
     },
     settings: {
         react: {

--- a/e2e/team.spec.ts
+++ b/e2e/team.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, Locator } from '@playwright/test'
 
 /** Verifies visibility of the name, title, and photo
- * 
+ *
  * @param card The Locator for the TeamMember Card
  * @param name The name to find
  * @param title The title to find, if defined

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,7 @@
             },
             "devDependencies": {
                 "@playwright/test": "1.44.1",
-                "@stylistic/eslint-plugin": "^2.3.0",
-                "@stylistic/eslint-plugin-ts": "1.7.2",
+                "@stylistic/eslint-plugin": "2.6.1",
                 "@testing-library/jest-dom": "6.4.2",
                 "@testing-library/react": "15.0.2",
                 "@testing-library/user-event": "14.5.2",
@@ -1681,17 +1680,17 @@
             "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
         },
         "node_modules/@stylistic/eslint-plugin": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.3.0.tgz",
-            "integrity": "sha512-rtiz6u5gRyyEZp36FcF1/gHJbsbT3qAgXZ1qkad6Nr/xJ9wrSJkiSFFQhpYVTIZ7FJNRJurEcumZDCwN9dEI4g==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.6.1.tgz",
+            "integrity": "sha512-UT0f4t+3sQ/GKW7875NiIIjZJ1Bh4gd7JNfoIkwIQyWqO7wGd0Pqzu0Ho30Ka8MNF5lm++SkVeqAk26vGxoUpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@stylistic/eslint-plugin-js": "2.3.0",
-                "@stylistic/eslint-plugin-jsx": "2.3.0",
-                "@stylistic/eslint-plugin-plus": "2.3.0",
-                "@stylistic/eslint-plugin-ts": "2.3.0",
-                "@types/eslint": "^8.56.10"
+                "@stylistic/eslint-plugin-js": "2.6.1",
+                "@stylistic/eslint-plugin-jsx": "2.6.1",
+                "@stylistic/eslint-plugin-plus": "2.6.1",
+                "@stylistic/eslint-plugin-ts": "2.6.1",
+                "@types/eslint": "^9.6.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1701,66 +1700,16 @@
             }
         },
         "node_modules/@stylistic/eslint-plugin-js": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.7.2.tgz",
-            "integrity": "sha512-ZYX7C5p7zlHbACwFLU+lISVh6tdcRP/++PWegh2Sy0UgMT5kU0XkPa2tKWEtJYzZmPhJxu9LxbnWcnE/tTwSDQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/eslint": "^8.56.8",
-                "acorn": "^8.11.3",
-                "escape-string-regexp": "^4.0.0",
-                "eslint-visitor-keys": "^3.4.3",
-                "espree": "^9.6.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "eslint": ">=8.40.0"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin-js/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin-jsx": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.3.0.tgz",
-            "integrity": "sha512-tsQ0IEKB195H6X9A4iUSgLLLKBc8gUBWkBIU8tp1/3g2l8stu+PtMQVV/VmK1+3bem5FJCyvfcZIQ/WF1fsizA==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.6.1.tgz",
+            "integrity": "sha512-iLOiVzcvqzDGD9U0EuVOX680v+XOPiPAjkxWj+Q6iV2GLOM5NB27tKVOpJY7AzBhidwpRbaLTgg3T4UzYx09jw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@stylistic/eslint-plugin-js": "^2.3.0",
-                "@types/eslint": "^8.56.10",
-                "estraverse": "^5.3.0",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "peerDependencies": {
-                "eslint": ">=8.40.0"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin-jsx/node_modules/@stylistic/eslint-plugin-js": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.3.0.tgz",
-            "integrity": "sha512-lQwoiYb0Fs6Yc5QS3uT8+T9CPKK2Eoxc3H8EnYJgM26v/DgtW+1lvy2WNgyBflU+ThShZaHm3a6CdD9QeKx23w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/eslint": "^8.56.10",
-                "acorn": "^8.11.3",
+                "@types/eslint": "^9.6.0",
+                "acorn": "^8.12.1",
                 "eslint-visitor-keys": "^4.0.0",
-                "espree": "^10.0.1"
+                "espree": "^10.1.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1769,7 +1718,7 @@
                 "eslint": ">=8.40.0"
             }
         },
-        "node_modules/@stylistic/eslint-plugin-jsx/node_modules/eslint-visitor-keys": {
+        "node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
             "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
@@ -1782,7 +1731,7 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@stylistic/eslint-plugin-jsx/node_modules/espree": {
+        "node_modules/@stylistic/eslint-plugin-js/node_modules/espree": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
             "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
@@ -1800,6 +1749,25 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/@stylistic/eslint-plugin-jsx": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.6.1.tgz",
+            "integrity": "sha512-5qHLXqxfY6jubAQfDqrifv41fx7gaqA9svDaChxMI6JiHpEBfh+PXxmm3g+B8gJCYVBTC62Rjl0Ny5QabK58bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@stylistic/eslint-plugin-js": "^2.6.1",
+                "@types/eslint": "^9.6.0",
+                "estraverse": "^5.3.0",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.40.0"
+            }
+        },
         "node_modules/@stylistic/eslint-plugin-jsx/node_modules/picomatch": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
@@ -1814,31 +1782,31 @@
             }
         },
         "node_modules/@stylistic/eslint-plugin-plus": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.3.0.tgz",
-            "integrity": "sha512-xboPWGUU5yaPlR+WR57GwXEuY4PSlPqA0C3IdNA/+1o2MuBi95XgDJcZiJ9N+aXsqBXAPIpFFb+WQ7QEHo4f7g==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.6.1.tgz",
+            "integrity": "sha512-z/IYu/q8ipApzNam5utSU+BrXg4pK/Gv9xNbr4eWv/bZppvTWJU62xCO4nw/6r2dHNPnqc7uCHEC7GMlBnPY0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/eslint": "^8.56.10",
-                "@typescript-eslint/utils": "^7.12.0"
+                "@types/eslint": "^9.6.0",
+                "@typescript-eslint/utils": "^8.0.0"
             },
             "peerDependencies": {
                 "eslint": "*"
             }
         },
         "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/scope-manager": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.15.0.tgz",
-            "integrity": "sha512-Q/1yrF/XbxOTvttNVPihxh1b9fxamjEoz2Os/Pe38OHwxC24CyCqXxGTOdpb4lt6HYtqw9HetA/Rf6gDGaMPlw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.0.0.tgz",
+            "integrity": "sha512-V0aa9Csx/ZWWv2IPgTfY7T4agYwJyILESu/PVqFtTFz9RIS823mAze+NbnBI8xiwdX3iqeQbcTYlvB04G9wyQw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "7.15.0",
-                "@typescript-eslint/visitor-keys": "7.15.0"
+                "@typescript-eslint/types": "8.0.0",
+                "@typescript-eslint/visitor-keys": "8.0.0"
             },
             "engines": {
-                "node": "^18.18.0 || >=20.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1846,13 +1814,13 @@
             }
         },
         "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/types": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.15.0.tgz",
-            "integrity": "sha512-aV1+B1+ySXbQH0pLK0rx66I3IkiZNidYobyfn0WFsdGhSXw+P3YOqeTq5GED458SfB24tg+ux3S+9g118hjlTw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0.tgz",
+            "integrity": "sha512-wgdSGs9BTMWQ7ooeHtu5quddKKs5Z5dS+fHLbrQI+ID0XWJLODGMHRfhwImiHoeO2S5Wir2yXuadJN6/l4JRxw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^18.18.0 || >=20.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1860,14 +1828,14 @@
             }
         },
         "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.15.0.tgz",
-            "integrity": "sha512-gjyB/rHAopL/XxfmYThQbXbzRMGhZzGw6KpcMbfe8Q3nNQKStpxnUKeXb0KiN/fFDR42Z43szs6rY7eHk0zdGQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.0.0.tgz",
+            "integrity": "sha512-5b97WpKMX+Y43YKi4zVcCVLtK5F98dFls3Oxui8LbnmRsseKenbbDinmvxrWegKDMmlkIq/XHuyy0UGLtpCDKg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/types": "7.15.0",
-                "@typescript-eslint/visitor-keys": "7.15.0",
+                "@typescript-eslint/types": "8.0.0",
+                "@typescript-eslint/visitor-keys": "8.0.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -1876,7 +1844,7 @@
                 "ts-api-utils": "^1.3.0"
             },
             "engines": {
-                "node": "^18.18.0 || >=20.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1889,40 +1857,40 @@
             }
         },
         "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/utils": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.15.0.tgz",
-            "integrity": "sha512-hfDMDqaqOqsUVGiEPSMLR/AjTSCsmJwjpKkYQRo1FNbmW4tBwBspYDwO9eh7sKSTwMQgBw9/T4DHudPaqshRWA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.0.0.tgz",
+            "integrity": "sha512-k/oS/A/3QeGLRvOWCg6/9rATJL5rec7/5s1YmdS0ZU6LHveJyGFwBvLhSRBv6i9xaj7etmosp+l+ViN1I9Aj/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "7.15.0",
-                "@typescript-eslint/types": "7.15.0",
-                "@typescript-eslint/typescript-estree": "7.15.0"
+                "@typescript-eslint/scope-manager": "8.0.0",
+                "@typescript-eslint/types": "8.0.0",
+                "@typescript-eslint/typescript-estree": "8.0.0"
             },
             "engines": {
-                "node": "^18.18.0 || >=20.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.56.0"
+                "eslint": "^8.57.0 || ^9.0.0"
             }
         },
         "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.15.0.tgz",
-            "integrity": "sha512-Hqgy/ETgpt2L5xueA/zHHIl4fJI2O4XUE9l4+OIfbJIRSnTJb/QscncdqqZzofQegIJugRIF57OJea1khw2SDw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.0.0.tgz",
+            "integrity": "sha512-oN0K4nkHuOyF3PVMyETbpP5zp6wfyOvm7tWhTMfoqxSSsPmJIh6JNASuZDlODE8eE+0EB9uar+6+vxr9DBTYOA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "7.15.0",
+                "@typescript-eslint/types": "8.0.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
-                "node": "^18.18.0 || >=20.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1946,33 +1914,35 @@
             }
         },
         "node_modules/@stylistic/eslint-plugin-ts": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.7.2.tgz",
-            "integrity": "sha512-szX89YPocwCe4T0eT3alj7MwEzDHt5+B+kb/vQfSSLIjI9CGgoWrgj50zU8PtaDctTh4ZieFBzU/lRmkSUo0RQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.6.1.tgz",
+            "integrity": "sha512-Mxl1VMorEG1Hc6oBYPD0+KIJOWkjEF1R0liL7wWgKfwpqOkgmnh5lVdZBrYyfRKOE4RlGcwEFTNai1IW6orgVg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@stylistic/eslint-plugin-js": "1.7.2",
-                "@types/eslint": "^8.56.8",
-                "@typescript-eslint/utils": "^6.21.0"
+                "@stylistic/eslint-plugin-js": "2.6.1",
+                "@types/eslint": "^9.6.0",
+                "@typescript-eslint/utils": "^8.0.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "peerDependencies": {
                 "eslint": ">=8.40.0"
             }
         },
         "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-            "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.0.0.tgz",
+            "integrity": "sha512-V0aa9Csx/ZWWv2IPgTfY7T4agYwJyILESu/PVqFtTFz9RIS823mAze+NbnBI8xiwdX3iqeQbcTYlvB04G9wyQw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0"
+                "@typescript-eslint/types": "8.0.0",
+                "@typescript-eslint/visitor-keys": "8.0.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1980,12 +1950,13 @@
             }
         },
         "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-            "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0.tgz",
+            "integrity": "sha512-wgdSGs9BTMWQ7ooeHtu5quddKKs5Z5dS+fHLbrQI+ID0XWJLODGMHRfhwImiHoeO2S5Wir2yXuadJN6/l4JRxw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1993,22 +1964,23 @@
             }
         },
         "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-            "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.0.0.tgz",
+            "integrity": "sha512-5b97WpKMX+Y43YKi4zVcCVLtK5F98dFls3Oxui8LbnmRsseKenbbDinmvxrWegKDMmlkIq/XHuyy0UGLtpCDKg==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
+                "@typescript-eslint/types": "8.0.0",
+                "@typescript-eslint/visitor-keys": "8.0.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
-                "minimatch": "9.0.3",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^1.3.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2021,231 +1993,47 @@
             }
         },
         "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/utils": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-            "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.0.0.tgz",
+            "integrity": "sha512-k/oS/A/3QeGLRvOWCg6/9rATJL5rec7/5s1YmdS0ZU6LHveJyGFwBvLhSRBv6i9xaj7etmosp+l+ViN1I9Aj/Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@types/json-schema": "^7.0.12",
-                "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "semver": "^7.5.4"
+                "@typescript-eslint/scope-manager": "8.0.0",
+                "@typescript-eslint/types": "8.0.0",
+                "@typescript-eslint/typescript-estree": "8.0.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "eslint": "^8.57.0 || ^9.0.0"
             }
         },
         "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-            "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin/node_modules/@stylistic/eslint-plugin-js": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.3.0.tgz",
-            "integrity": "sha512-lQwoiYb0Fs6Yc5QS3uT8+T9CPKK2Eoxc3H8EnYJgM26v/DgtW+1lvy2WNgyBflU+ThShZaHm3a6CdD9QeKx23w==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.0.0.tgz",
+            "integrity": "sha512-oN0K4nkHuOyF3PVMyETbpP5zp6wfyOvm7tWhTMfoqxSSsPmJIh6JNASuZDlODE8eE+0EB9uar+6+vxr9DBTYOA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/eslint": "^8.56.10",
-                "acorn": "^8.11.3",
-                "eslint-visitor-keys": "^4.0.0",
-                "espree": "^10.0.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "peerDependencies": {
-                "eslint": ">=8.40.0"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin/node_modules/@stylistic/eslint-plugin-ts": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.3.0.tgz",
-            "integrity": "sha512-wqOR38/uz/0XPnHX68ftp8sNMSAqnYGjovOTN7w00xnjS6Lxr3Sk7q6AaxWWqbMvOj7V2fQiMC5HWAbTruJsCg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@stylistic/eslint-plugin-js": "2.3.0",
-                "@types/eslint": "^8.56.10",
-                "@typescript-eslint/utils": "^7.12.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "peerDependencies": {
-                "eslint": ">=8.40.0"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.15.0.tgz",
-            "integrity": "sha512-Q/1yrF/XbxOTvttNVPihxh1b9fxamjEoz2Os/Pe38OHwxC24CyCqXxGTOdpb4lt6HYtqw9HetA/Rf6gDGaMPlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "7.15.0",
-                "@typescript-eslint/visitor-keys": "7.15.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || >=20.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/types": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.15.0.tgz",
-            "integrity": "sha512-aV1+B1+ySXbQH0pLK0rx66I3IkiZNidYobyfn0WFsdGhSXw+P3YOqeTq5GED458SfB24tg+ux3S+9g118hjlTw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || >=20.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.15.0.tgz",
-            "integrity": "sha512-gjyB/rHAopL/XxfmYThQbXbzRMGhZzGw6KpcMbfe8Q3nNQKStpxnUKeXb0KiN/fFDR42Z43szs6rY7eHk0zdGQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "@typescript-eslint/types": "7.15.0",
-                "@typescript-eslint/visitor-keys": "7.15.0",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "minimatch": "^9.0.4",
-                "semver": "^7.6.0",
-                "ts-api-utils": "^1.3.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || >=20.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/utils": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.15.0.tgz",
-            "integrity": "sha512-hfDMDqaqOqsUVGiEPSMLR/AjTSCsmJwjpKkYQRo1FNbmW4tBwBspYDwO9eh7sKSTwMQgBw9/T4DHudPaqshRWA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "7.15.0",
-                "@typescript-eslint/types": "7.15.0",
-                "@typescript-eslint/typescript-estree": "7.15.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || >=20.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.56.0"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.15.0.tgz",
-            "integrity": "sha512-Hqgy/ETgpt2L5xueA/zHHIl4fJI2O4XUE9l4+OIfbJIRSnTJb/QscncdqqZzofQegIJugRIF57OJea1khw2SDw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "7.15.0",
+                "@typescript-eslint/types": "8.0.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
-                "node": "^18.18.0 || >=20.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-            "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin/node_modules/espree": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
-            "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "acorn": "^8.12.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.0.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@stylistic/eslint-plugin/node_modules/minimatch": {
+        "node_modules/@stylistic/eslint-plugin-ts/node_modules/minimatch": {
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
             "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
@@ -2579,10 +2367,11 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.56.10",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
-            "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
+            "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     },
     "devDependencies": {
         "@playwright/test": "1.44.1",
-        "@stylistic/eslint-plugin-ts": "1.7.2",
+        "@stylistic/eslint-plugin": "2.6.1",
         "@testing-library/jest-dom": "6.4.2",
         "@testing-library/react": "15.0.2",
         "@testing-library/user-event": "14.5.2",

--- a/src/theme/customColorConfig.ts
+++ b/src/theme/customColorConfig.ts
@@ -9,7 +9,7 @@ declare module '@mui/material/styles' {
     interface Palette {
         tertiary: Palette['primary'];
     }
-  
+
     interface PaletteOptions {
         tertiary?: PaletteOptions['primary'];
     }

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -35,7 +35,7 @@ const theme = createTheme({
             paper: deepPurple[900]
         },
         divider: lightBlue[300]
-      
+
     },
     typography
 })


### PR DESCRIPTION
Part of #51 

## What changed 🧐
- Add some new eslint rules to remove extra whitespace within and in line ends
- Add a rule to prevent `any` type
- switch from `stylistic/ts` to the newer `stylistic` which consolidates all the `js` `ts` `jsx` rules into one package


## How did you test it? 🧪

I tested manually by adding code that broke each rule, and then running `npm run lint` to ensure that the error is caught

1. Add extra spaces in the middle of a line
2. Add extra spaces at the end of a line
3. Define a variable with `any` type:
```ts
let foo: any = 5
```
