### PR TITLE
fix e2e tests

### DIFF
--- a/e2e/team.spec.ts
+++ b/e2e/team.spec.ts
@@ -64,7 +64,7 @@ test('shows the team in Japanese', async ({ page, viewport }) => {
         await teamContainer.click({ force: true })
     }
 
-    const heading = teamContainer.getByText('✨ リーダーシップ・チーム ✨')
+    const heading = teamContainer.getByText('✨ リーダーシップチーム ✨')
     await expect(heading).toBeVisible()
 
     const cards = await teamContainer.getByLabel('team-member-card').all()


### PR DESCRIPTION
Missed e2e test from #86 

## What changed 🧐
Fix the e2e tests

## How did you test it? 🧪

`npm run test:e2e` should pass
