### PR TITLE
Minimal Style Updates and Footer Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "react": "19.1.0",
                 "react-dom": "19.1.0",
                 "react-i18next": "15.5.1",
-                "react-router-dom": "7.5.2",
+                "react-router-dom": "^7.6.0",
                 "styled-components": "6.1.8"
             },
             "devDependencies": {
@@ -3757,7 +3757,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
             "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
@@ -7185,14 +7184,12 @@
             }
         },
         "node_modules/react-router": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.2.tgz",
-            "integrity": "sha512-9Rw8r199klMnlGZ8VAsV/I8WrIF6IyJ90JQUdboupx1cdkgYqwnrYjH+I/nY/7cA1X5zia4mDJqH36npP7sxGQ==",
-            "license": "MIT",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.0.tgz",
+            "integrity": "sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==",
             "dependencies": {
                 "cookie": "^1.0.1",
-                "set-cookie-parser": "^2.6.0",
-                "turbo-stream": "2.4.0"
+                "set-cookie-parser": "^2.6.0"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -7208,12 +7205,11 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.5.2.tgz",
-            "integrity": "sha512-yk1XW8Fj7gK7flpYBXF3yzd2NbX6P7Kxjvs2b5nu1M04rb5pg/Zc4fGdBNTeT4eDYL2bvzWNyKaIMJX/RKHTTg==",
-            "license": "MIT",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.0.tgz",
+            "integrity": "sha512-DYgm6RDEuKdopSyGOWZGtDfSm7Aofb8CCzgkliTjtu/eDuB0gcsv6qdFhhi8HdtmA+KHkt5MfZ5K2PdzjugYsA==",
             "dependencies": {
-                "react-router": "7.5.2"
+                "react-router": "7.6.0"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -7614,8 +7610,7 @@
         "node_modules/set-cookie-parser": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-            "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-            "license": "MIT"
+            "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
@@ -8419,12 +8414,6 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
             "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        },
-        "node_modules/turbo-stream": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-            "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-            "license": "ISC"
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-i18next": "15.5.1",
-        "react-router-dom": "^7.6.0",
+        "react-router-dom": "7.5.2",
         "styled-components": "6.1.8"
     },
     "devDependencies": {
@@ -44,8 +44,8 @@
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.31.0",
         "@vitejs/plugin-react": "4.4.1",
-        "@vitest/coverage-istanbul": "3.1.3",
         "@vitest/ui": "3.1.3",
+        "@vitest/coverage-istanbul": "3.1.3",
         "eslint": "8.57.0",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "dev": "vite",
         "build": "tsc && vite build",
         "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+        "lint:fix": "eslint . --ext ts,tsx --fix",
         "preview": "vite preview",
         "prepare": "husky",
         "test": "vitest",
@@ -28,7 +29,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-i18next": "15.5.1",
-        "react-router-dom": "7.5.2",
+        "react-router-dom": "^7.6.0",
         "styled-components": "6.1.8"
     },
     "devDependencies": {
@@ -43,8 +44,8 @@
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.31.0",
         "@vitejs/plugin-react": "4.4.1",
-        "@vitest/ui": "3.1.3",
         "@vitest/coverage-istanbul": "3.1.3",
+        "@vitest/ui": "3.1.3",
         "eslint": "8.57.0",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "5.2.0",

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { useLocation } from 'react-router-dom'
 import BottomNavigation from '@mui/material/BottomNavigation'
 import Paper from '@mui/material/Paper'
 import InstagramIcon from '@mui/icons-material/Instagram'
@@ -8,17 +8,51 @@ import GitHubIcon from '@mui/icons-material/GitHub'
 import EventIcon from '@mui/icons-material/Event'
 import FooterIcon from './FooterIcon'
 
+const Footer = () => {
+    const location = useLocation()
+    const path = location.pathname
+    const isHome = /^\/$/.test(path)
 
-const Footer: FC = () => {
-    return <Paper sx={{ position: 'static', bottom: 0, left: 0, right: 0 }} elevation={0} aria-label="footer">
-        <BottomNavigation sx={{ backgroundColor: '#512da8' }}>
-            <FooterIcon label="Events" icon={<EventIcon />} href="https://womeninsoftware-japan.connpass.com/" />
-            <FooterIcon label="Instagram" icon={<InstagramIcon />} href="https://www.instagram.com/womeninsoftwarejp/" />
-            <FooterIcon label="LinkedIn" icon={<LinkedInIcon />} href="https://www.linkedin.com/company/womeninsoftwarejp/" />
-            <FooterIcon label="Facebook" icon={<FacebookIcon />} href="https://www.facebook.com/womeninsoftwarejp/" />
-            <FooterIcon label="GitHub" icon={<GitHubIcon />} href="https://github.com/WomenInSoftwareEngineeringJP" />
-        </BottomNavigation>
-    </Paper>
+    return (
+        <Paper
+            sx={{
+                position: `${isHome ? 'fixed' : 'relative'}`,
+                bottom: 0,
+                left: 0,
+                right: 0,
+            }}
+            elevation={0}
+            aria-label="footer"
+        >
+            <BottomNavigation sx={{ backgroundColor: '#512da8' }}>
+                <FooterIcon
+                    label="Events"
+                    icon={<EventIcon />}
+                    href="https://womeninsoftware-japan.connpass.com/"
+                />
+                <FooterIcon
+                    label="Instagram"
+                    icon={<InstagramIcon />}
+                    href="https://www.instagram.com/womeninsoftwarejp/"
+                />
+                <FooterIcon
+                    label="LinkedIn"
+                    icon={<LinkedInIcon />}
+                    href="https://www.linkedin.com/company/womeninsoftwarejp/"
+                />
+                <FooterIcon
+                    label="Facebook"
+                    icon={<FacebookIcon />}
+                    href="https://www.facebook.com/womeninsoftwarejp/"
+                />
+                <FooterIcon
+                    label="GitHub"
+                    icon={<GitHubIcon />}
+                    href="https://github.com/WomenInSoftwareEngineeringJP"
+                />
+            </BottomNavigation>
+        </Paper>
+    )
 }
 
 export default Footer

--- a/src/components/Header/DesktopHeader.tsx
+++ b/src/components/Header/DesktopHeader.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-
+import { Container } from '@mui/material'
 import Stack from '@mui/material/Stack'
 import Toolbar from '@mui/material/Toolbar'
 import Typography from '@mui/material/Typography'
@@ -7,7 +7,6 @@ import { styled } from '@mui/material/styles'
 import SideDrawer from '../SideDrawer/SideDrawer'
 import StyledNavLink from '@/components/StyledNavLink/StyledNavLink'
 import { useTranslation } from 'react-i18next'
-
 
 const StyledToolbar = styled(Toolbar)(({ theme }) => ({
     alignItems: 'flex-start',
@@ -17,32 +16,75 @@ const StyledToolbar = styled(Toolbar)(({ theme }) => ({
     '@media all': {
         minHeight: 80,
     },
-    maxWidth: '100%'
+    maxWidth: '100%',
 }))
-
-
 
 const DesktopHeader: FC = () => {
     const { t } = useTranslation()
 
-    return <StyledToolbar aria-label="desktop-toolbar">
-        <Stack direction='row' spacing={2} sx={{ alignItems: 'center' }}>
-            <SideDrawer />
-            <StyledNavLink to="/" style={{ textDecoration: 'none', color: 'white' }}>
-                <Typography variant="h1">WiSE Japan</Typography>
-                <Typography variant="caption">{t('header.subtitle')}</Typography>
-            </StyledNavLink>
-            <StyledNavLink to="/team" style={{ textDecoration: 'none', color: 'white' }}>
-                <Typography variant="overline">{t('header.team')}</Typography>
-            </StyledNavLink>
-            <StyledNavLink to="/jobs" style={{ textDecoration: 'none', color: 'white' }}>
-                <Typography variant="overline">{t('header.job')}</Typography>
-            </StyledNavLink>
-            <StyledNavLink to="/codeofconduct" style={{ textDecoration: 'none', color: 'white' }}>
-                <Typography variant="overline">{t('header.codeOfConduct')}</Typography>
-            </StyledNavLink>
-        </Stack>
-    </StyledToolbar>
+    return (
+        <Container>
+            <StyledToolbar aria-label="desktop-toolbar" disableGutters>
+                <Stack direction="row" sx={{ width: '100%' }}>
+                    {/* Center: Navigation */}
+                    <Stack
+                        direction="row"
+                        spacing={4}
+                        justifyContent="space-between"
+                        alignItems="center"
+                        sx={{ flexGrow: 1 }}
+                    >
+                        <StyledNavLink
+                            to="/"
+                            style={{ textDecoration: 'none', color: 'white' }}
+                        >
+                            <Typography variant="h1">WiSE Japan</Typography>
+                            <Typography variant="caption">
+                                {t('header.subtitle')}
+                            </Typography>
+                        </StyledNavLink>
+                        <Stack display={'flex'} flexDirection={'row'} gap={2}>
+                            <StyledNavLink
+                                to="/team"
+                                style={{
+                                    textDecoration: 'none',
+                                    color: 'white',
+                                }}
+                            >
+                                <Typography variant="overline">
+                                    {t('header.team')}
+                                </Typography>
+                            </StyledNavLink>
+                            <StyledNavLink
+                                to="/jobs"
+                                style={{
+                                    textDecoration: 'none',
+                                    color: 'white',
+                                }}
+                            >
+                                <Typography variant="overline">
+                                    {t('header.job')}
+                                </Typography>
+                            </StyledNavLink>
+                            <StyledNavLink
+                                to="/codeofconduct"
+                                style={{
+                                    textDecoration: 'none',
+                                    color: 'white',
+                                }}
+                            >
+                                <Typography variant="overline">
+                                    {t('header.codeOfConduct')}
+                                </Typography>
+                            </StyledNavLink>
+                            {/* Left: Side Drawer */}
+                            <SideDrawer />
+                        </Stack>
+                    </Stack>
+                </Stack>
+            </StyledToolbar>
+        </Container>
+    )
 }
 
 export default DesktopHeader

--- a/src/components/Header/MobileHeader.tsx
+++ b/src/components/Header/MobileHeader.tsx
@@ -5,13 +5,23 @@ import StyledNavLink from '@/components/StyledNavLink/StyledNavLink'
 import SideDrawer from '../SideDrawer/SideDrawer'
 
 const MobileHeader: FC = () => {
-    return <Toolbar aria-label="mobile-toolbar">
-        <SideDrawer />
-        <StyledNavLink to="/" style={{ textDecoration: 'none', color: 'white' }}>
-            <Typography variant="h2">WiSE Japan</Typography>
-            <Typography variant="caption">Women in Software Engineering Japan</Typography>
-        </StyledNavLink>
-    </Toolbar>
+    return (
+        <Toolbar
+            aria-label="mobile-toolbar"
+            sx={{ justifyContent: 'space-between' }}
+        >
+            <StyledNavLink
+                to="/"
+                style={{ textDecoration: 'none', color: 'white' }}
+            >
+                <Typography variant="h2">WiSE Japan</Typography>
+                <Typography variant="caption">
+                    Women in Software Engineering Japan
+                </Typography>
+            </StyledNavLink>
+            <SideDrawer />
+        </Toolbar>
+    )
 }
 
 export default MobileHeader

--- a/src/components/TeamMemberCard/TeamMemberCard.tsx
+++ b/src/components/TeamMemberCard/TeamMemberCard.tsx
@@ -8,7 +8,7 @@ import { getI18n } from 'react-i18next'
 import OptionalLinkWrapper from '../OptionalLinkWrapper/OptionalLinkWrapper'
 
 interface TeamMemberCardProps {
-    member: TeamMember
+    member: TeamMember;
 }
 
 const TeamMemberCard: FC<TeamMemberCardProps> = ({ member }) => {
@@ -27,25 +27,25 @@ const TeamMemberCard: FC<TeamMemberCardProps> = ({ member }) => {
         }
     }, [member, i18n.language])
 
-    return <OptionalLinkWrapper url={member.url}>
-        <Card sx={{ height: 420 }} aria-label="team-member-card">
-            <CardMedia
-                sx={{ height: 300, width: 300 }}
-                image={member.image || 'Placeholder.png'}
-                title={name}
-                alt-text={`${name} photo`}
-            />
-            <CardContent>
-                <Typography variant='h6'>
-                    {name}
-                </Typography>
-                <Typography variant="subtitle1">
-                    {title}
-                </Typography>
-
-            </CardContent>
-        </Card>
-    </OptionalLinkWrapper>
+    return (
+        <OptionalLinkWrapper url={member.url}>
+            <Card
+                sx={{ height: 420, width: '100%' }}
+                aria-label="team-member-card"
+            >
+                <CardMedia
+                    sx={{ height: 300, width: 345 }}
+                    image={member.image || 'Placeholder.png'}
+                    title={name}
+                    alt-text={`${name} photo`}
+                />
+                <CardContent>
+                    <Typography variant="h6">{name}</Typography>
+                    <Typography variant="subtitle1">{title}</Typography>
+                </CardContent>
+            </Card>
+        </OptionalLinkWrapper>
+    )
 }
 
 export default TeamMemberCard

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,8 @@
+html,
+body {
+    height: 100%;
+}
+
+.section-padding {
+    padding: 7rem 0 7rem 0;
+}

--- a/src/routes/BaseLayout.tsx
+++ b/src/routes/BaseLayout.tsx
@@ -1,9 +1,7 @@
 import { FC, Suspense } from 'react'
 import Header from '@/components/Header/Header'
 import Footer from '@/components/Footer/Footer'
-import {
-    Outlet,
-} from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
 
 // loading component for suspense fallback
 const Loader = () => (
@@ -13,11 +11,13 @@ const Loader = () => (
 )
 
 const BaseLayout: FC = () => {
-    return <Suspense fallback={<Loader />}>
-        <Header />
-        <Outlet />
-        <Footer />
-    </Suspense>
+    return (
+        <Suspense fallback={<Loader />}>
+            <Header />
+            <Outlet />
+            <Footer />
+        </Suspense>
+    )
 }
 
 export default BaseLayout

--- a/src/routes/CodeOfConduct/CodeOfConduct.tsx
+++ b/src/routes/CodeOfConduct/CodeOfConduct.tsx
@@ -7,56 +7,134 @@ import { useTranslation } from 'react-i18next'
 const CodeOfConduct: FC = () => {
     const { t } = useTranslation()
 
-    return <Container style={{ padding: 32 }}>
-        <Stack spacing={2}>
-            <Typography variant='h1'>
-                {t('header.codeOfConduct')}
-            </Typography>
-            <Typography variant='body1' >
-                Women in Software Engineering Japan (WiSE Japan) is dedicated to providing an empowering experience for everyone who participates in or supports our community. Our events are intended to inspire women to excel in technology careers, and anyone who is there for this purpose is welcome. Because we value the safety and security of our members and strive to have an inclusive community, we do not tolerate harassment of members or event participants in any form. This Code of Conduct was created to clearly define what we mean by a harassment-free experience, so that our community and those who support it are clear about our intent and have access to procedures for addressing issues, should they arise.
-            </Typography>
-            <Typography variant='h3' >
-                Women in Software Engineering Japan Statement of Intent
-            </Typography>
-            <Typography variant='body1' >
-                WiSE Japan values the safety and security of all of our members and, because of that, we will not tolerate any form of harassment or discrimination. Our goal is to provide a safe and secure environment for our members, and to this end we have taken the following actions:
-                Provided a statement of intent and code of conduct for events
-                Explicitly outlined and defined forms of harassment and discrimination
-                Clearly outlined the consequences for those who engage in harassing or discriminatory behavior
-                Provided a system for reporting any harassing or discriminatory behavior
-                Committed to a periodic review of the code of conduct
-            </Typography>
+    return (
+        <Container className="section-padding">
+            <Stack spacing={2}>
+                <Typography variant="h1">
+                    {t('header.codeOfConduct')}
+                </Typography>
+                <Typography variant="body1">
+                    Women in Software Engineering Japan (WiSE Japan) is
+                    dedicated to providing an empowering experience for everyone
+                    who participates in or supports our community. Our events
+                    are intended to inspire women to excel in technology
+                    careers, and anyone who is there for this purpose is
+                    welcome. Because we value the safety and security of our
+                    members and strive to have an inclusive community, we do not
+                    tolerate harassment of members or event participants in any
+                    form. This Code of Conduct was created to clearly define
+                    what we mean by a harassment-free experience, so that our
+                    community and those who support it are clear about our
+                    intent and have access to procedures for addressing issues,
+                    should they arise.
+                </Typography>
+                <Typography variant="h3">
+                    Women in Software Engineering Japan Statement of Intent
+                </Typography>
+                <Typography variant="body1">
+                    WiSE Japan values the safety and security of all of our
+                    members and, because of that, we will not tolerate any form
+                    of harassment or discrimination. Our goal is to provide a
+                    safe and secure environment for our members, and to this end
+                    we have taken the following actions: Provided a statement of
+                    intent and code of conduct for events Explicitly outlined
+                    and defined forms of harassment and discrimination Clearly
+                    outlined the consequences for those who engage in harassing
+                    or discriminatory behavior Provided a system for reporting
+                    any harassing or discriminatory behavior Committed to a
+                    periodic review of the code of conduct
+                </Typography>
 
-            <Typography variant='h3' >
-                Code of Conduct for Women in Software Engineering Japan Events
-            </Typography>
+                <Typography variant="h3">
+                    Code of Conduct for Women in Software Engineering Japan
+                    Events
+                </Typography>
 
-            <Typography variant='body1' >
-                Women in Software Engineering Japan is an organization (hopefully a nonprofit again soon) dedicated to inspiring women to excel in technology careers. We are committed to our mission statement and equally committed to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, ability, physical appearance, body size, race, ethnicity, age, religion, socioeconomic status, caste or creed. We do not tolerate harassment of event participants in any form. Event participants violating these rules may be sanctioned or expelled permanently, at the discretion of the event organizers, which in most cases are members of the WiSE Japan leadership team.
-                Forms of Harassment and Discrimination
-                Forms of harassment include sexual language and imagery, sexist, racist, and exclusionary jokes, and acts that insult or belittle other event attendees in any way. These are unacceptable at any and all WiSE Japan events. Other forms of harassment and discriminatory behavior include, but are not limited to: offensive verbal comments related to gender, gender identity and expression, sexual orientation, ability, physical appearance, body size, race, ethnicity, religion, socioeconomic status, caste or creed; sexual images in public spaces; deliberate intimidation; stalking; following; unwarranted photography or recording; sustained disruption of event programming; inappropriate physical contact; and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to immediately comply and may be removed from the event without warning by any member of WiSE Japan leadership. Participants are expected to comply with the WiSE Japan Code of Conduct at all event venues.
-                Consequences for Harassment and Discrimination
-                If a participant engages in behavior which is harassing or discriminatory in any way, the event organizers may take any action they deem appropriate. These actions include, but are not limited to, issuing a warning or expulsion from all future events. If a warning or expulsion is issued, WiSE Japan leadership may elect to share this information with directors from any network that the participant joins in the future.
-                If a participant engages in behavior which is harassing or discriminatory in any way at events in more than one network, WiSE Japan leadership may take any action they deem appropriate. These actions include, but are not limited to, issuing a warning or expulsion from all future WiSE Japan events in all networks.
-            </ Typography>
+                <Typography variant="body1">
+                    Women in Software Engineering Japan is an organization
+                    (hopefully a nonprofit again soon) dedicated to inspiring
+                    women to excel in technology careers. We are committed to
+                    our mission statement and equally committed to providing a
+                    harassment-free experience for everyone regardless of
+                    gender, gender identity and expression, sexual orientation,
+                    ability, physical appearance, body size, race, ethnicity,
+                    age, religion, socioeconomic status, caste or creed. We do
+                    not tolerate harassment of event participants in any form.
+                    Event participants violating these rules may be sanctioned
+                    or expelled permanently, at the discretion of the event
+                    organizers, which in most cases are members of the WiSE
+                    Japan leadership team. Forms of Harassment and
+                    Discrimination Forms of harassment include sexual language
+                    and imagery, sexist, racist, and exclusionary jokes, and
+                    acts that insult or belittle other event attendees in any
+                    way. These are unacceptable at any and all WiSE Japan
+                    events. Other forms of harassment and discriminatory
+                    behavior include, but are not limited to: offensive verbal
+                    comments related to gender, gender identity and expression,
+                    sexual orientation, ability, physical appearance, body size,
+                    race, ethnicity, religion, socioeconomic status, caste or
+                    creed; sexual images in public spaces; deliberate
+                    intimidation; stalking; following; unwarranted photography
+                    or recording; sustained disruption of event programming;
+                    inappropriate physical contact; and unwelcome sexual
+                    attention. Participants asked to stop any harassing behavior
+                    are expected to immediately comply and may be removed from
+                    the event without warning by any member of WiSE Japan
+                    leadership. Participants are expected to comply with the
+                    WiSE Japan Code of Conduct at all event venues. Consequences
+                    for Harassment and Discrimination If a participant engages
+                    in behavior which is harassing or discriminatory in any way,
+                    the event organizers may take any action they deem
+                    appropriate. These actions include, but are not limited to,
+                    issuing a warning or expulsion from all future events. If a
+                    warning or expulsion is issued, WiSE Japan leadership may
+                    elect to share this information with directors from any
+                    network that the participant joins in the future. If a
+                    participant engages in behavior which is harassing or
+                    discriminatory in any way at events in more than one
+                    network, WiSE Japan leadership may take any action they deem
+                    appropriate. These actions include, but are not limited to,
+                    issuing a warning or expulsion from all future WiSE Japan
+                    events in all networks.
+                </Typography>
 
-            <Typography variant='h3' >
-                How to Report Harassment and Discrimination
-            </Typography>
-            <Typography variant='body1' >
-                If you experience or notice harassment, discrimination, or any of the unacceptable behaviors outlined herein at a WiSE Japan event, or have any other concerns, please report the incident as soon as possible. To report an incident, take one of the following actions: inform the event organizer on site; inform another organizer in your network; report the incident to WiSE Japan Leadership by reaching out to
-                Ann Kilzer (Interim Director).
-                We encourage you to report any incident of harassment, discrimination, or unacceptable behavior as soon as possible. WiSE Japan leadership will take all appropriate actions to mitigate risk factors moving forward and continue to provide a safe and secure environment for all WiSE Japan members. WiSE Japan leadership is happy to assist attendees in contacting venue security, local law enforcement, or otherwise aid those experiencing harassment so that they feel safe for the duration of the event. The WiSE Japan leadership team will take great care to ensure that the assistance provided meets the needs of attendees who were affected.
-            </Typography>
+                <Typography variant="h3">
+                    How to Report Harassment and Discrimination
+                </Typography>
+                <Typography variant="body1">
+                    If you experience or notice harassment, discrimination, or
+                    any of the unacceptable behaviors outlined herein at a WiSE
+                    Japan event, or have any other concerns, please report the
+                    incident as soon as possible. To report an incident, take
+                    one of the following actions: inform the event organizer on
+                    site; inform another organizer in your network; report the
+                    incident to WiSE Japan Leadership by reaching out to Ann
+                    Kilzer (Interim Director). We encourage you to report any
+                    incident of harassment, discrimination, or unacceptable
+                    behavior as soon as possible. WiSE Japan leadership will
+                    take all appropriate actions to mitigate risk factors moving
+                    forward and continue to provide a safe and secure
+                    environment for all WiSE Japan members. WiSE Japan
+                    leadership is happy to assist attendees in contacting venue
+                    security, local law enforcement, or otherwise aid those
+                    experiencing harassment so that they feel safe for the
+                    duration of the event. The WiSE Japan leadership team will
+                    take great care to ensure that the assistance provided meets
+                    the needs of attendees who were affected.
+                </Typography>
 
-            <Typography variant='h3' >
-                Periodic Review
-            </Typography>
-            <Typography variant='body1' >
-                WiSE Japan strives to create a positive and inclusive environment. As such, the WiSE Japan leadership team commits to an annual review of the Code of Conduct to ensure that it continues to align with this goal and address the needs of our community. WiSE Japan welcomes feedback from its members. A feedback form will be established soon
-            </Typography>
-        </Stack>
-    </Container >
+                <Typography variant="h3">Periodic Review</Typography>
+                <Typography variant="body1">
+                    WiSE Japan strives to create a positive and inclusive
+                    environment. As such, the WiSE Japan leadership team commits
+                    to an annual review of the Code of Conduct to ensure that it
+                    continues to align with this goal and address the needs of
+                    our community. WiSE Japan welcomes feedback from its
+                    members. A feedback form will be established soon
+                </Typography>
+            </Stack>
+        </Container>
+    )
 }
 
 export default CodeOfConduct

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -10,38 +10,37 @@ import theme from '@/theme/theme'
 const Home: FC = () => {
     const { t } = useTranslation()
 
-    const title = useMediaQuery(theme.breakpoints.down('sm')) ?
-        <Typography variant="h3" component="h1">{t('home.helloWorld')}</Typography> :
-        <Typography variant="h1" >{t('home.helloWorld')}</Typography>
+    const title = useMediaQuery(theme.breakpoints.down('sm')) ? (
+        <Typography variant="h3" component="h1">
+            {t('home.helloWorld')}
+        </Typography>
+    ) : (
+        <Typography variant="h1">{t('home.helloWorld')}</Typography>
+    )
 
-    return <Container style={{ padding: 32 }}>
-        <Stack spacing={2}>
+    return (
+        <Container className="section-padding">
+            <Stack spacing={2}>
+                {title}
+                <Typography variant="body1">{t('home.paragraph1')}</Typography>
+                <Typography variant="body1">{t('home.paragraph2')}</Typography>
 
-            {title}
-            <Typography variant="body1">
-                {t('home.paragraph1')}
-            </Typography>
-            <Typography variant="body1">
-                {t('home.paragraph2')}
-            </Typography>
+                <Typography variant="body1">{t('home.paragraph3')}</Typography>
 
-            <Typography variant="body1">
-                {t('home.paragraph3')}
-            </Typography>
+                <Button
+                    variant="contained"
+                    href="https://join.slack.com/t/wise-japan/shared_invite/zt-2h79966bm-dE7SyiGvv2CXBxbz_0JzKw"
+                    target="_blank"
+                >
+                    {t('home.joinUs')}
+                </Button>
 
-            <Button
-                variant='contained'
-                href='https://join.slack.com/t/wise-japan/shared_invite/zt-2h79966bm-dE7SyiGvv2CXBxbz_0JzKw'
-                target='_blank'
-            >
-                {t('home.joinUs')}
-            </Button>
-
-            <Typography variant="body2">
-                {t('home.whoShouldJoin')}
-            </Typography>
-        </Stack>
-    </Container>
+                <Typography variant="body2">
+                    {t('home.whoShouldJoin')}
+                </Typography>
+            </Stack>
+        </Container>
+    )
 }
 
 export default Home

--- a/src/routes/JobBoard/JobBoard.tsx
+++ b/src/routes/JobBoard/JobBoard.tsx
@@ -5,20 +5,22 @@ import { useTranslation } from 'react-i18next'
 import job from '@/routes/JobBoard/jobs.json'
 import JobData from '@/types/JobListing'
 
-const JobBoard:FC = () => {
+const JobBoard: FC = () => {
     const { t } = useTranslation()
 
     const jobGrid: ReactNode[] = []
     job.forEach((jobDescription: JobData) => {
-        jobGrid.push(<JobCard job={jobDescription}/>)
+        jobGrid.push(<JobCard job={jobDescription} />)
     })
 
-    return <Container style={{ padding: 32 }} aria-label="job-board-container">
-        <Stack spacing={4}>
-            <Typography variant="h1">{t('job.title')}</Typography>
-            {jobGrid}
-        </Stack>
-    </Container>
+    return (
+        <Container className="section-padding" aria-label="job-board-container">
+            <Stack spacing={4}>
+                <Typography variant="h1">{t('job.title')}</Typography>
+                {jobGrid}
+            </Stack>
+        </Container>
+    )
 }
 
 export default JobBoard

--- a/src/routes/Team/Team.tsx
+++ b/src/routes/Team/Team.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { FC } from 'react'
 import Container from '@mui/material/Container'
 import Grid from '@mui/material/Grid'
 import Stack from '@mui/material/Stack'
@@ -8,25 +8,23 @@ import TeamMember from '@/types/TeamMember'
 import TeamMemberCard from '@/components/TeamMemberCard/TeamMemberCard'
 import team from './team.json'
 
-
 const Team: FC = () => {
     const { t } = useTranslation()
 
-    const teamGrid: ReactNode[] = []
-    team.forEach((member: TeamMember) => {
-        teamGrid.push(<Grid key={member.nameEN}>
-            <TeamMemberCard member={member} />
-        </Grid>)
-    })
-
-    return <Container style={{ padding: 32 }} aria-label="team-container">
-        <Stack spacing={2}>
-            <Typography variant="h1">{t('team.title')}</Typography>
-            <Grid container spacing={2}>
-                {teamGrid}
-            </Grid>
-        </Stack>
-    </Container>
+    return (
+        <Container className="section-padding" aria-label="team-container">
+            <Stack spacing={2}>
+                <Typography variant="h1">{t('team.title')}</Typography>
+                <Grid container spacing={4}>
+                    {team.map((member: TeamMember) => (
+                        <Grid item xs={12} sm={6} md={4} key={member.nameEN}>
+                            <TeamMemberCard member={member} />
+                        </Grid>
+                    ))}
+                </Grid>
+            </Stack>
+        </Container>
+    )
 }
 
 export default Team


### PR DESCRIPTION
Resolves #<issue number>

## What changed 🧐
*  I added a fix on the footer for the homepage since there's minimal content. (If more content is added and the page gets lengthier this wont be needed anymore). (This is only for desktop, on mobile the footer will be set back to relative position so it doesn't cover the content)

* Added lint:fix npm script to auto fix errors before pushing
* Updated header styling and moved menu to the right
* Cleaned up spacing and added a section-padding class to keep the page sections a little more centered
* Fixed teams grid styling

Desktop View
<img width="1370" alt="Screenshot 2025-05-20 at 3 13 02 PM" src="https://github.com/user-attachments/assets/17b6a38a-87ee-4ef8-9bf4-0af8bf879a17" />


Mobile View
<img width="370" alt="Screenshot 2025-05-20 at 3 12 30 PM" src="https://github.com/user-attachments/assets/0208b828-3b2e-4980-9416-705742e458c0" />


See [CONTRIBUTING](https://github.com/WomenInSoftwareEngineeringJP/home/blob/main/CONTRIBUTING.md) for guidelines


## How did you test it? 🧪

Manually test footer on homepage on desktop and mobile views
