### PR TITLE
Configure Dependabot to do joint update of packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,23 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      mui:
+        patterns:
+          - "@mui/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      emotion:
+        patterns:
+          - "@emotion/*"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"


### PR DESCRIPTION
Resolves #144 

## What changed 🧐
- Set Groups and patterns for dependencies that must be updated in sync. This will remove the manual intervention I've had to do and allow us to easily approve and merge

See this blog for details: https://dev.to/boyum/improve-your-dependabot-experience-with-grouping-and-version-ignoring-4mji or the GitHub docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--

## How did you test it? 🧪

We'll have to test in prod due to the way dependabot works. At a minimum, I've confirmed the yaml is properly formatted https://yamlchecker.com/
