### PR TITLE
Remove @sirbully from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @ann-kilzer @sirbully
+*       @ann-kilzer
 


### PR DESCRIPTION


## What changed 🧐
- Remove @sirbully from CODEOWNERS


## How did you test it? 🧪

We'll need to test it live and ensure new PRs only assign Ann as a reviewer.
