### PR TITLE
update slack invitation on home page menu

### DIFF
--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -31,7 +31,7 @@ const Home: FC = () => {
 
             <Button
                 variant='contained'
-                href='https://join.slack.com/t/wise-japan/shared_invite/zt-2h79966bm-dE7SyiGvv2CXBxbz_0JzKw'
+                href='https://join.slack.com/t/wise-japan/shared_invite/zt-3day0p55s-f7cx26Q3ZLw0XB34SjbKIg'
                 target='_blank'
             >
                 {t('home.joinUs')}

--- a/src/routes/Home/__test__/Home.test.tsx
+++ b/src/routes/Home/__test__/Home.test.tsx
@@ -11,7 +11,7 @@ describe('Home Route', () => {
 
         const link = await screen.findByRole('link', { name: '✨ Join us on Slack ✨' })
         expect(link).toBeEnabled()
-        expect(link).toHaveAttribute('href', 'https://join.slack.com/t/wise-japan/shared_invite/zt-2h79966bm-dE7SyiGvv2CXBxbz_0JzKw')
+        expect(link).toHaveAttribute('href', 'https://join.slack.com/t/wise-japan/shared_invite/zt-3day0p55s-f7cx26Q3ZLw0XB34SjbKIg')
         expect(link).toHaveAttribute('target', '_blank')
     })
 


### PR DESCRIPTION
Resolves #<issue number>

## What changed 🧐
It was updated the Slack invitation link was updated.

## How did you test it? 🧪
Playwright (E2E) tests
