### PR TITLE
refactor: simplify the style for address row on EventCart

### DIFF
--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -108,7 +108,7 @@ const EventCard: FC<EventCardProps> = ({ event }) => {
                                     />}
                                 </Box>
                             </Grid>
-                            <Grid size={{ xs: 12, sm: 12 }} sx={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center' }}>
+                            <Grid size={12} sx={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center' }}>
                                 <PlaceIcon sx={{ marginRight: 2 }} />
                                 <Typography fontSize="body2">
                                     {event.place}{event.address ? ` · ${event.address}` : ''}


### PR DESCRIPTION
Resolves #65 

## What changed 🧐
Quick refactor to remove some not obvious you do the markup of the address part of the event card. 


## How did you test it? 🧪

- Go to the website
- Click on the "Events" link in the navigation (mobile or desktop)
- Check if the address row (Online or address of the event) is rendered correctly, it should be on it's own row

Desktop:
<img width="2345" height="1525" alt="image" src="https://github.com/user-attachments/assets/9a6ae20e-c584-4891-b876-0d0bdcfd9024" />

Mobile:
<img width="375" height="984" alt="image" src="https://github.com/user-attachments/assets/c8858c59-c2e0-4e16-9426-1fcf493ac280" />

