### PR TITLE
chore: skip patch and minor updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
Resolves #231 

## What changed 🧐
Modify the depandabot configuration to skip the patch and minor versions for all the dependencies. The frequency of the check is still weekly. 

Let's see if it helps :thinking: 

## How did you test it? 🧪

Wait :laughing: 

```shell
➜  WomenInSoftwareEngineeringJP-home git:(231-dependabot-monthly) npx @bugron/validate-dependabot-yaml@latest .github/dependabot.yml 
Need to install the following packages:
@bugron/validate-dependabot-yaml@0.3.1
Ok to proceed? (y) y

➜  WomenInSoftwareEngineeringJP-home git:(231-dependabot-monthly) echo $?      
0
```
