### PR TITLE
#332 Specified Node version in Github Action for Playwright and upgrading Playwright

### DIFF
--- a/.github/workflows/playwright-prod.yml
+++ b/.github/workflows/playwright-prod.yml
@@ -13,8 +13,11 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.56.1-noble
+      options: --user 1001
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
@@ -22,8 +25,6 @@ jobs:
         node-version: 24
     - name: Install dependencies
       run: npm ci
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
     - name: Run tests
       run: npm run test:e2e
     - name: Upload results

--- a/.github/workflows/playwright-prod.yml
+++ b/.github/workflows/playwright-prod.yml
@@ -15,17 +15,15 @@ jobs:
   test:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.56.1-noble
-      options: --user 1001
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 24.15.0
-        cache: npm
     - name: Install dependencies
       run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
     - name: Run tests
       run: npm run test:e2e
     - name: Upload results

--- a/.github/workflows/playwright-prod.yml
+++ b/.github/workflows/playwright-prod.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: 24.17.0
+        node-version: 24.15.0
         cache: npm
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/playwright-prod.yml
+++ b/.github/workflows/playwright-prod.yml
@@ -19,10 +19,11 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.56.1-noble
       options: --user 1001
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: 24
+        node-version: 24.17.0
+        cache: npm
     - name: Install dependencies
       run: npm ci
     - name: Run tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,8 +6,11 @@ on:
     branches: [ main, master ]
 jobs:
   test:
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.56.1-noble
+      options: --user 1001
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v4
@@ -17,8 +20,6 @@ jobs:
       run: |
         npm ci
         npm install wait-on
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
     - name: Build the app
       run: npm run build
     - name: Start Vite server and run tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 24.17.0
+        node-version: 24.15.0
         cache: npm
     - name: Install dependencies
       run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,10 +12,11 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.56.1-noble
       options: --user 1001
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 24
+        node-version: 24.17.0
+        cache: npm
     - name: Install dependencies
       run: |
         npm ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,19 +8,17 @@ jobs:
   test:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.56.1-noble
-      options: --user 1001
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
         node-version: 24.15.0
-        cache: npm
     - name: Install dependencies
       run: |
         npm ci
         npm install wait-on
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
     - name: Build the app
       run: npm run build
     - name: Start Vite server and run tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "@eslint/compat": "2.0.0",
                 "@eslint/eslintrc": "3.3.1",
                 "@eslint/js": "9.38.0",
-                "@playwright/test": "1.56.1",
+                "@playwright/test": "^1.60.0",
                 "@stylistic/eslint-plugin": "5.5.0",
                 "@testing-library/jest-dom": "6.6.3",
                 "@testing-library/react": "16.3.0",
@@ -677,6 +677,7 @@
             "version": "11.14.1",
             "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
             "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
                 "@emotion/babel-plugin": "^11.13.5",
@@ -1863,13 +1864,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-            "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+            "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.56.1"
+                "playwright": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -7334,13 +7335,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-            "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.56.1"
+                "playwright-core": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -7353,9 +7354,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-            "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@eslint/compat": "2.0.0",
         "@eslint/eslintrc": "3.3.1",
         "@eslint/js": "9.38.0",
-        "@playwright/test": "1.56.1",
+        "@playwright/test": "^1.60.0",
         "@stylistic/eslint-plugin": "5.5.0",
         "@testing-library/jest-dom": "6.6.3",
         "@testing-library/react": "16.3.0",


### PR DESCRIPTION
Resolves #332 

## What changed 🧐
Settings in the playwright.yaml and playwright-prod.yaml have been changed:
- increased timeout from 10s to 20s
<s>- instead of installing all playwright dependencies directly in GH Actions, I switched to a configuration that uses the official Playwright Docker image eliminating the need to install browser installation step</s>
This didn't fix the issue. What I did was specifying the node version to 24.15.0 and upgrading Playwright to 1.60 as recommended in [this issue](https://github.com/microsoft/playwright/issues/41133) on the Playwright repository

See [CONTRIBUTING](https://github.com/WomenInSoftwareEngineeringJP/home/blob/main/CONTRIBUTING.md) for guidelines

## How did you test it? 🧪

Opening a PR now to verify that this action is no longer hanging
